### PR TITLE
Fix: Safari filter vs blend mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2559,6 +2559,7 @@
               </g>
               <g id="Mask_Group_45-2" data-name="Mask Group 45" clip-path="url(#clip-path-16)">
                 <rect id="Image_35-2" style="filter: grayscale(1);" data-name="Image 35" width="355.62" height="237" transform="translate(5916.058 6978)" fill="url(#pattern-21)"/>
+                <rect id="Rectangle_35-2b" data-name="Rectangle 35-2b" width="356" height="238" transform="translate(5916.058 6978)" fill="#fff" style="mix-blend-mode: saturation;isolation: isolate"></rect>
               </g>
             </g>
             <rect id="Rectangle_278" data-name="Rectangle 278" width="84" height="60" transform="translate(743 6123)" fill="#141414"/>
@@ -2614,6 +2615,7 @@
                 </g>
                 <g id="Mask_Group_45-5" data-name="Mask Group 45" clip-path="url(#clip-path-16)">
                   <rect id="Image_35-5" style="filter: grayscale(1);" data-name="Image 35" width="355.62" height="237" transform="translate(5916.058 6978)" fill="url(#pattern-6)"/>
+                  <rect id="Rectangle_325-5b" data-name="Rectangle 325-5b" width="356" height="238" transform="translate(5916.058 6978)" fill="#fff" style="mix-blend-mode: saturation;isolation: isolate"></rect>
                 </g>
               </g>
               <rect id="Rectangle_319" data-name="Rectangle 319" width="98" height="84" transform="translate(320 6454)" fill="#141414"/>
@@ -3365,6 +3367,7 @@
               <g id="Group_1038" data-name="Group 1038" transform="translate(-358 -832)">
                 <g id="Mask_Group_74" data-name="Mask Group 74" transform="translate(4 3)" style="filter: grayscale(1);" clip-path="url(#clip-path-39)">
                   <path id="_49419136706_79b2544b91_o" data-name="49419136706_79b2544b91_o" d="M0,0H429.388V285.9H0Z" transform="translate(463 6715)" fill="url(#pattern-47)"/>
+                  <rect id="Rectangle_79b2544b91_o" data-name="Rectangle 79b2544b91_o" width="350" height="230" transform="translate(463 6715)" fill="#fff" style="mix-blend-mode: saturation;isolation: isolate"></rect>
                 </g>
                 <g id="Group_1023" data-name="Group 1023" transform="translate(4)">
                   <rect id="Rectangle_341" data-name="Rectangle 341" width="118" height="77" transform="translate(682 6939)" fill="#141414"/>
@@ -3436,6 +3439,7 @@
                 <g id="Group_796" data-name="Group 796" transform="translate(-5075 -914)">
                   <g id="Mask_Group_44-7" data-name="Mask Group 44" clip-path="url(#clip-path-16)">
                     <rect id="Image_34-7" data-name="Image 34" style="filter: grayscale(1);" width="355.62" height="237" transform="translate(5916.058 6978)" fill="url(#pattern-14)"/>
+                    <rect id="Rectangle_34-7b" data-name="Rectangle 34-7b" width="356" height="238" transform="translate(5916.058 6978)" fill="#fff" style="mix-blend-mode: saturation;isolation: isolate"></rect>
                   </g>
                   <g id="Mask_Group_45-7" data-name="Mask Group 45" clip-path="url(#clip-path-16)">
                   </g>
@@ -6059,6 +6063,7 @@
               </g>
               <g id="tablet-Mask_Group_45-3" style="filter: grayscale(1);" data-name="Mask Group 45" transform="translate(0 0)" clip-path="url(#tablet-clip-path-22)">
                 <rect id="tablet-Image_35-3" data-name="Image 35" width="319.074" height="212.644" transform="translate(-69.035)" fill="url(#tablet-pattern-26)"/>
+                <rect id="tablet-Rectangle_325b" data-name="Rectangle 325b" width="319.074" height="212.644" transform="translate(-69.035)" fill="#fff" style="mix-blend-mode: saturation;isolation: isolate"></rect>
               </g>
             </g>
             <rect id="tablet-Rectangle_481" data-name="Rectangle 481" width="54" height="54" transform="translate(907 6560)" fill="#141414"/>


### PR DESCRIPTION
Safari appears to have a bug where it doesn't recognize all filters when in an SVG. So instead, an isolated rectangle was used to blend mode the saturation.

This bug will be PoC'd and reported to Safari as well.