### PR TITLE
fix Blog post routes not rendering correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "ffdw-website",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffdw-website",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
-        "@agency-undone/au-nuxt-module-zero": "^1.0.16",
+        "@agency-undone/au-nuxt-module-zero": "^1.0.17",
         "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
         "@nuxt/content": "^1.15.0",
         "@nuxtjs/axios": "^5.13.6",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@agency-undone/au-nuxt-module-zero": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@agency-undone/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.16.tgz",
-      "integrity": "sha512-8bX9d/uYc5WUnyGi7JpHeRd1QhY/LgFXpCuzTn5opbt+7b9M3onJUZ2rj8y0sY3WFHuAgiMG2oJMcvA1mrzKeg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@agency-undone/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.17.tgz",
+      "integrity": "sha512-LuufXrXSaXivTJHGCu+PlV42LRL3z7oJzfQKw1nVllerUeITkQTgOUMicti5WGTfe0AhVePtVlubAR0AADcE5g==",
       "dependencies": {
         "@nuxtjs/sitemap": "^2.4.0",
         "cookie": "^0.4.1",
@@ -17371,9 +17371,9 @@
   },
   "dependencies": {
     "@agency-undone/au-nuxt-module-zero": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@agency-undone/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.16.tgz",
-      "integrity": "sha512-8bX9d/uYc5WUnyGi7JpHeRd1QhY/LgFXpCuzTn5opbt+7b9M3onJUZ2rj8y0sY3WFHuAgiMG2oJMcvA1mrzKeg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@agency-undone/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.17.tgz",
+      "integrity": "sha512-LuufXrXSaXivTJHGCu+PlV42LRL3z7oJzfQKw1nVllerUeITkQTgOUMicti5WGTfe0AhVePtVlubAR0AADcE5g==",
       "requires": {
         "@nuxtjs/sitemap": "^2.4.0",
         "cookie": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=16.13.0"
   },
   "dependencies": {
-    "@agency-undone/au-nuxt-module-zero": "^1.0.16",
+    "@agency-undone/au-nuxt-module-zero": "^1.0.17",
     "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
     "@nuxt/content": "^1.15.0",
     "@nuxtjs/axios": "^5.13.6",


### PR DESCRIPTION
This PR fixes an issue where virtual navigation to blog post paths was working, but server-side navigation was not. This was because we use a catch-all route (`_id.vue`) to render blog posts whereas the `@nuxt/content` module attempts to render blog posts under `/blog/<id>`. Since we don't nest blog posts under `/blog/<id>`, the routes were not being generated. As well, these routes need to be added manually. This fix was implemented in `au-nuxt-module-zero` and requires the following criteria to pass in order to generate routes:

1. `@nuxt/content` module must be present
2. `@/content/blog` directory must be present
3. Generates routes only for `.md` files in `@/content/blog` directory