### PR TITLE
style: temporarily hide new grants section

### DIFF
--- a/pages/grants.vue
+++ b/pages/grants.vue
@@ -66,6 +66,7 @@ export default {
 <style lang="scss" scoped>
 // /////////////////////////////////////////////////////////////////// Specifics
 ::v-deep #info_0 {
+  display: none;
   padding-bottom: 3rem;
   @include small {
     padding-bottom: 2rem;


### PR DESCRIPTION
Temporarily hides the `info_0` section near the top of the Grants page