### PR TITLE
fix: corrected the date format injected by Forestry

### DIFF
--- a/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
+++ b/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
@@ -2,12 +2,12 @@
 tags: []
 title: Announcing Filecoin Foundation for the Decentralized Web’s First Open Request
   for Proposals
-date: 2022-04-19T07:00:00Z
+date: 2022-04-19T07:00:00.000+00:00
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is launching an
   open request for proposals (RFP). We’re looking for projects that support our core
   mission — to ensure the permanent preservation of humanity’s most important information.
-featured: false
+featured: true
 recommendedPosts:
 - ''
 image: "/images/ffdw-request-for-proposals.png"

--- a/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
+++ b/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
@@ -2,7 +2,8 @@
 tags: []
 title: Announcing Filecoin Foundation for the Decentralized Web’s First Open Request
   for Proposals
-date: 2022-04-19T07:00:00.000+00:00
+date: April 19 2022
+sortDate: 2022-04-19
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is launching an
   open request for proposals (RFP). We’re looking for projects that support our core

--- a/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
+++ b/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
@@ -6,7 +6,7 @@ description: Melba Roy Mouton was a statistician and computer scientist whose co
   uses and documentation practices, but also how it is taught to future generations.
 author: Filecoin Foundation for the Decentralized Web
 date: June 01 2021
-sortDate: '2021-06-01'
+sortDate: 2021-06-01
 image: "/images/page-blog/melba-roy.jpeg"
 recommendedPosts:
 - History


### PR DESCRIPTION
Changed the date format to correctly order blog posts. Forestry was injected the incorrect format (this will require further adjustment, this is just a more immediate hotfix)