### PR TITLE
fix: Slate data restructure

### DIFF
--- a/components/SlateVideoBlock.vue
+++ b/components/SlateVideoBlock.vue
@@ -4,7 +4,6 @@
     <template v-for="(video, index) in videos">
 
       <VideoBlock
-        v-if="video.isPublic"
         :key="index"
         type="slate-video"
         :block="video" />
@@ -42,10 +41,15 @@ export default {
     videos () {
       if (this.slateCollections) {
         const collection = this.slateCollections.find((col) => { return col.slatename === this.block.slatename })
-        return collection.objects.filter((obj) => { return !obj.url })
+        // console.log(collection)
+        return collection.objects //.filter((obj) => { return !obj.url })
       }
       return []
     }
+  },
+
+  mounted () {
+    console.log(this.videos)
   }
 }
 </script>

--- a/components/VideoBlock.vue
+++ b/components/VideoBlock.vue
@@ -71,15 +71,15 @@ export default {
         if (this.block.data.coverImage) {
           return `https://gateway.ipfs.io/ipfs/${this.block.data.coverImage.cid}`
         }
-        if (this.block.data.link) {
-          return this.block.data.link.image
+        if (this.block.data.linkImage) {
+          return this.block.data.linkImage
         }
         return false
       }
       return this.block.preview_image
     },
     url () {
-      return this.isSlateVideo ? `https://gateway.ipfs.io/ipfs/${this.block.cid}` : this.block.url
+      return !this.isSlateVideo ? this.block.url : `https://gateway.ipfs.io/ipfs/${this.block.cid}`
     },
     tint () {
       return this.block.tint
@@ -104,6 +104,10 @@ export default {
     slateVideoType () {
       return this.isSlateVideo ? this.block.data.type : ''
     }
+  },
+
+  mounted () {
+    console.log(this.block)
   },
 
   methods: {

--- a/components/VideoBlock.vue
+++ b/components/VideoBlock.vue
@@ -2,11 +2,22 @@
   <div class="block video-block">
 
     <div class="preview-container" @click="openModal">
-      <div class="overlay">
+
+      <div :class="['overlay', { fallback: !preview_image }]">
         <IconPlay class="play-icon" />
       </div>
-      <div class="tint"></div>
-      <img :src="preview_image" class="preview-image" />
+      <div :class="['tint', { fallback: !preview_image }]"></div>
+
+      <img
+        v-if="preview_image"
+        :src="preview_image"
+        class="preview-image" />
+
+      <VideoPreviewImage
+        v-if="!preview_image"
+        variant="C"
+        class="preview-image" />
+
     </div>
 
     <div v-if="date" class="metadata">
@@ -40,6 +51,7 @@ import { mapActions } from 'vuex'
 
 import IconPlay from '@/components/icons/Play'
 import Button from '@/components/Button'
+import VideoPreviewImage from '@/components/svgs/VideoPreviewImage'
 
 // ====================================================================== Export
 export default {
@@ -47,7 +59,8 @@ export default {
 
   components: {
     IconPlay,
-    Button
+    Button,
+    VideoPreviewImage
   },
 
   props: {
@@ -106,10 +119,6 @@ export default {
     }
   },
 
-  mounted () {
-    console.log(this.block)
-  },
-
   methods: {
     ...mapActions({
       setModal: 'global/setModal'
@@ -139,7 +148,7 @@ export default {
   &:hover {
     ::v-deep .play-icon {
       transition: 250ms ease-in;
-      transform: scale(1.1);
+      transform: translate(-50%, -50%) scale(1.15);
     }
   }
 }
@@ -154,9 +163,18 @@ export default {
   padding: 0.6875rem 0 0 0.6875rem;
   z-index: 15;
   transition: 250ms ease-out;
+  &.fallback {
+    ::v-deep rect {
+      fill: $haiti;
+    }
+  }
 }
 
 ::v-deep .play-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 3.75rem;
   transition: 250ms ease-out;
 }
@@ -172,6 +190,9 @@ export default {
   background-color: $haiti;
   opacity: 0.3;
   z-index: 10;
+  &.fallback {
+    display: none;
+  }
 }
 
 .preview-image {

--- a/components/svgs/VideoPreviewImage.vue
+++ b/components/svgs/VideoPreviewImage.vue
@@ -1,0 +1,70 @@
+<template>
+  <svg width="565" height="373" viewBox="0 0 565 373" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <template v-if="variant === 'A'">
+      <rect width="565" height="373" fill="url(#paint0_linear_421_3533)"/>
+      <rect x="16" y="19" width="532" height="334" fill="black"/>
+      <defs>
+        <linearGradient id="paint0_linear_421_3533" x1="0" y1="373" x2="565" y2="373" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#B5B5FA"/>
+          <stop offset="1" stop-color="#BAFE36"/>
+        </linearGradient>
+      </defs>
+    </template>
+
+    <template v-if="variant === 'B'">
+      <rect width="565" height="373" fill="url(#paint0_linear_421_3589)"/>
+      <rect x="528" y="157" width="37" height="37" fill="#070517"/>
+      <rect x="507" y="259" width="29" height="28" fill="#070517"/>
+      <rect x="536" y="259" width="29" height="28" fill="#070517"/>
+      <rect x="536" y="230" width="15" height="14" fill="#070517"/>
+      <rect x="507" y="316" width="15" height="14" fill="#070517"/>
+      <rect x="449" y="216" width="15" height="14" fill="#070517"/>
+      <rect x="449" y="360" width="15" height="14" fill="#070517"/>
+      <rect x="478" y="287" width="29" height="29" fill="#070517"/>
+      <rect x="536" y="345" width="29" height="28" fill="#070517"/>
+      <rect x="478" y="230" width="29" height="29" fill="#070517"/>
+      <rect x="536" y="287" width="29" height="29" fill="#070517"/>
+      <defs>
+        <linearGradient id="paint0_linear_421_3589" x1="0" y1="373" x2="565" y2="373" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#B5B5FA"/>
+          <stop offset="1" stop-color="#BAFE36"/>
+        </linearGradient>
+      </defs>
+    </template>
+
+    <template v-if="variant === 'C'">
+      <rect width="565" height="373" fill="url(#paint0_linear_421_3567)"/>
+      <rect x="448" width="117" height="117" fill="#070517"/>
+      <rect y="305" width="68" height="68" fill="#070517"/>
+      <rect x="410" y="118" width="37" height="37" fill="#070517"/>
+      <rect x="68" y="268" width="37" height="37" fill="#070517"/>
+      <rect x="31" y="231" width="37" height="37" fill="#070517"/>
+      <rect x="79" y="217" width="15" height="14" fill="#070517"/>
+      <defs>
+        <linearGradient id="paint0_linear_421_3567" x1="0" y1="373" x2="565" y2="373" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#B5B5FA"/>
+          <stop offset="1" stop-color="#BAFE36"/>
+        </linearGradient>
+      </defs>
+    </template>
+  </svg>
+</template>
+
+<script>
+// ====================================================================== Export
+export default {
+  name: 'VideoPreviewImage1',
+
+  props: {
+    variant: {
+      type: String,
+      required: false,
+      default: 'A'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// ///////////////////////////////////////////////////////////////////// General
+</style>


### PR DESCRIPTION
Slate added changes to their data structure which produced breaking changes with our data parsing and subsequent video rendering on pages with slate video collections. The parsing logic has been tweaked to adhere to slate's new data structure and fallback images have been implemented in cases where no image url is provided.