### PR TITLE
feat: Consilidated blogpost sort date

### DIFF
--- a/.forestry/front_matter/templates/blog-post-front-matter.yml
+++ b/.forestry/front_matter/templates/blog-post-front-matter.yml
@@ -11,7 +11,7 @@ fields:
   label: Date
   description: The date on which the post was created
   config:
-    required: false
+    required: true
     date_format: 
     time_format: 
     display_utc: false

--- a/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
+++ b/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
@@ -6,7 +6,7 @@ tags:
 - Research
 title: Announcing Filecoin Foundation for the Decentralized Web’s First Open Request
   for Proposals
-date: April 19 2022
+date: 2022-04-19
 sortDate: '2022-04-19'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is launching an

--- a/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
+++ b/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
@@ -7,7 +7,6 @@ tags:
 title: Announcing Filecoin Foundation for the Decentralized Web’s First Open Request
   for Proposals
 date: 2022-04-19
-sortDate: '2022-04-19'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is launching an
   open request for proposals (RFP). We’re looking for projects that support our core

--- a/content/blog/announcing-the-decentralized-future-council.md
+++ b/content/blog/announcing-the-decentralized-future-council.md
@@ -5,7 +5,6 @@ tags:
 - Education
 title: Announcing the Decentralized Future Council
 date: 2022-03-11
-sortDate: '2022-03-11'
 author: Filecoin Foundation for the Decentralized Web
 description: The Decentralized Future Council (DFC) is a new organization dedicated
   to advocacy and education for the emerging decentralized web and related technologies.

--- a/content/blog/announcing-the-decentralized-future-council.md
+++ b/content/blog/announcing-the-decentralized-future-council.md
@@ -4,7 +4,7 @@ tags:
 - Advocacy
 - Education
 title: Announcing the Decentralized Future Council
-date: March 11 2022
+date: 2022-03-11
 sortDate: '2022-03-11'
 author: Filecoin Foundation for the Decentralized Web
 description: The Decentralized Future Council (DFC) is a new organization dedicated

--- a/content/blog/announcing-the-starling-lab.md
+++ b/content/blog/announcing-the-starling-lab.md
@@ -1,15 +1,20 @@
 ---
 featured: false
 title: Announcing The Starling Lab
-description: The Filecoin Foundation for the Decentralized Web (FFDW) and Protocol Labs are thrilled to announce a multi-year commitment to The Starling Lab, a new research center tackling the technical and ethical challenges of establishing trust in the most sensitive digital records of our human history.
+description: The Filecoin Foundation for the Decentralized Web (FFDW) and Protocol
+  Labs are thrilled to announce a multi-year commitment to The Starling Lab, a new
+  research center tackling the technical and ethical challenges of establishing trust
+  in the most sensitive digital records of our human history.
 author: Filecoin Foundation for the Decentralized Web
-date: June 10 2021
-sortDate: 2021-06-10
-image: '/images/page-blog/starling-lab-image.jpg'
+date: 2022-06-10
+sortDate: '2021-06-10'
+image: "/images/page-blog/starling-lab-image.jpg"
 recommendedPosts: []
-tags: ['Governance', 'Innovation']
----
+tags:
+- Governance
+- Innovation
 
+---
 [![Announcing The Starling Lab video preview image](https://i.ytimg.com/vi/szltLBFoQg0/hqdefault.jpg)](https://www.youtube.com/watch?v=szltLBFoQg0)
 
 The Filecoin Foundation for the Decentralized Web (FFDW) and Protocol Labs are thrilled to announce a multi-year commitment to The Starling Lab, a new research center tackling the technical and ethical challenges of establishing trust in the most sensitive digital records of our human history.

--- a/content/blog/announcing-the-starling-lab.md
+++ b/content/blog/announcing-the-starling-lab.md
@@ -7,7 +7,6 @@ description: The Filecoin Foundation for the Decentralized Web (FFDW) and Protoc
   in the most sensitive digital records of our human history.
 author: Filecoin Foundation for the Decentralized Web
 date: 2022-06-10
-sortDate: '2021-06-10'
 image: "/images/page-blog/starling-lab-image.jpg"
 recommendedPosts: []
 tags:

--- a/content/blog/big-ideas-driving-the-decentralized-web.md
+++ b/content/blog/big-ideas-driving-the-decentralized-web.md
@@ -5,7 +5,7 @@ tags:
 - Open Source
 - Decentralized Data Storage
 title: Big Ideas Driving the Decentralized Web
-date: September 28 2022
+date: 2022-09-28
 author: ''
 description: We are at a fork in the road when it comes to building an internet that
   enhances trust, allows users to maintain privacy, incentivizes entrepreneurs to

--- a/content/blog/big-ideas-driving-the-decentralized-web.md
+++ b/content/blog/big-ideas-driving-the-decentralized-web.md
@@ -17,7 +17,6 @@ description: We are at a fork in the road when it comes to building an internet 
 featured: true
 recommendedPosts: []
 image: "/images/0928-ffdw-glossary.png"
-sortDate: '2022-09-28'
 
 ---
 We are at a fork in the road when it comes to building an internet that enhances trust, allows users to maintain privacy, incentivizes entrepreneurs to build safe and secure systems, and enables the preservation of the world’s most important information for future generations. At Filecoin Foundation for the Decentralized Web (FFDW), we believe that the Internet must return to its original – more decentralized – architecture. Some call this direction “Web3”; some call it the decentralized web or“DWeb.”

--- a/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
+++ b/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
@@ -5,7 +5,6 @@ tags:
 - Internet Evolution
 title: Check out our Docuseries “Exploring the Decentralized Web”
 date: 2022-01-21
-sortDate: '2022-01-21'
 author: Filecoin Foundation for the Decentralized Web
 description: We recently launched Exploring the Decentralized Web, a 12-part documentary
   series produced by Filecoin Foundation for the Decentralized Web (FFDW). Featuring

--- a/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
+++ b/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
@@ -4,7 +4,7 @@ tags:
 - Digital Identity
 - Internet Evolution
 title: Check out our Docuseries “Exploring the Decentralized Web”
-date: January 21 2022
+date: 2022-01-21
 sortDate: '2022-01-21'
 author: Filecoin Foundation for the Decentralized Web
 description: We recently launched Exploring the Decentralized Web, a 12-part documentary

--- a/content/blog/exploring-the-decentralized-web-episodes-5-8.md
+++ b/content/blog/exploring-the-decentralized-web-episodes-5-8.md
@@ -6,7 +6,7 @@ tags:
 - Economies of Trust
 - Browsers and dApps
 title: 'Exploring the Decentralized Web: Episodes 5–8'
-date: February 15 2022
+date: 2022-02-15
 sortDate: '2022-02-15'
 author: Filecoin Foundation for the Decentralized Web
 description: Episodes 5–8 dive into some of the most impactful topics in the Web3

--- a/content/blog/exploring-the-decentralized-web-episodes-5-8.md
+++ b/content/blog/exploring-the-decentralized-web-episodes-5-8.md
@@ -7,7 +7,6 @@ tags:
 - Browsers and dApps
 title: 'Exploring the Decentralized Web: Episodes 5–8'
 date: 2022-02-15
-sortDate: '2022-02-15'
 author: Filecoin Foundation for the Decentralized Web
 description: Episodes 5–8 dive into some of the most impactful topics in the Web3
   space –from privacy, identity, and user control, to blockchain economics, dApps,
@@ -39,7 +38,7 @@ Hear more from experts about the distinction of open-source projects, incentive 
 
 In Episode 7, experts explore applications and use cases for blockchain technology. Beyond cryptocurrency, they dive into the mechanics of trustless transactions, network participants within a blockchain ecosystem, and how data ownership and control work within these systems. Guests include Jonathan Dotan of[ Starling](https://www.starlinglab.org/), Zooko Wilcox-O’Hearn of[ Zcash](https://z.cash/), Marta Belcher of Filecoin Foundation for the Decentralized Web, Patrick Collins of[ Chainlink](https://chain.link/), Mariano Conti of[ MakerDAO](https://makerdao.com/en/), Urban Osvald of the[ Web3 Foundation](https://web3.foundation/), Brad Kam of[ Unstoppable Domains](https://unstoppabledomains.com/), Sarah Friend — artist and software engineer, Kristin Smith of the[ Blockchain Association](https://theblockchainassociation.org/), and Matt Stephenson of[ Planck](https://planckdata.com/).
 
-[**Episode 8: "Browsers and dApps"**](https://www.youtube.com/watch?v=wF_a2vR4zxQ) 
+[**Episode 8: "Browsers and dApps"**](https://www.youtube.com/watch?v=wF_a2vR4zxQ)
 
 In Episode 8, _Exploring the Decentrlaized Web_ explores the history and benefits of Web3 browsers, like Brave and Opera, which leverage peer-to-peer protocols and cryptocurrency wallets. This episode dives into how the next version of web browsers will return _lost agency_ to users and re-establish web browsers as a tool that serves users rather than the developer or parent company. It also explores the benefits of IPFS, including content addressing and how it gives users greater control over their own data. Guests include Danny O’Brien of the Filecoin Foundation for the Decentralized Web, Marcia Hofmann — electronic privacy attorney, Carson Farmer of[ Textile](https://www.textile.io/), Brad Kam of[ Unstoppable Domains](https://unstoppabledomains.com/) and Dietrich Ayala of[ IPFS](https://ipfs.io/).
 

--- a/content/blog/exploring-the-decentralized-web-episodes-9-12.md
+++ b/content/blog/exploring-the-decentralized-web-episodes-9-12.md
@@ -4,8 +4,8 @@ tags:
 - Digital Creator Economy
 - Communities and Coordination
 title: Exploring the Decentralized Web (Episodes 9–12)
-date: March 3 2022
-sortDate: 2022-03-10
+date: 2022-03-03
+sortDate: '2022-03-10'
 author: Filecoin Foundation for the Decentralized Web
 description: Decentralized web technology is enabling web developers and users alike
   to solve some of the issues that arose during the Web2 era, such as a lack of community

--- a/content/blog/exploring-the-decentralized-web-episodes-9-12.md
+++ b/content/blog/exploring-the-decentralized-web-episodes-9-12.md
@@ -5,7 +5,6 @@ tags:
 - Communities and Coordination
 title: Exploring the Decentralized Web (Episodes 9–12)
 date: 2022-03-03
-sortDate: '2022-03-10'
 author: Filecoin Foundation for the Decentralized Web
 description: Decentralized web technology is enabling web developers and users alike
   to solve some of the issues that arose during the Web2 era, such as a lack of community

--- a/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
+++ b/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
@@ -2,8 +2,8 @@
 tags: []
 title: FFDW and EASIER Data Initiative Collaborate to Upload Spatial Data to Filecoin
   Network
-date: October 12 2022
-sortDate: 2022-10-12
+date: 2022-10-12
+sortDate: '2022-10-12'
 author: ''
 description: Filecoin Foundation for the Decentralized Web (FFDW) is excited to announce
   our collaboration with the EASIER Data Initiative at the University of Maryland,

--- a/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
+++ b/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
@@ -3,7 +3,6 @@ tags: []
 title: FFDW and EASIER Data Initiative Collaborate to Upload Spatial Data to Filecoin
   Network
 date: 2022-10-12
-sortDate: '2022-10-12'
 author: ''
 description: Filecoin Foundation for the Decentralized Web (FFDW) is excited to announce
   our collaboration with the EASIER Data Initiative at the University of Maryland,
@@ -28,8 +27,8 @@ This Initiative will first focus on uploading data from Landsat 9–the latest s
 
 The EASIER Data Initiative is building a next-generation platform for spatial data, which refers to any interaction or observation that can be referenced to a location on the globe. The location data industry is a [$12 billion market](https://themarkup.org/privacy/2021/09/30/theres-a-multibillion-dollar-market-for-your-phones-location-data) and is often cited as covering [60-80% of global data products](https://www.esri.com/content/dam/esrisites/sitecore-archive/Files/Pdfs/library/whitepapers/pdfs/reveal-more-value.pdf) according to industry experts. Because the amount of data is so vast, the Initiative's work has the potential to benefit organizations – from local governments and universities to federal agencies and NGOs – who are responsible for planning, research, and decision-making. For example, location data can help predict weather patterns or understand the implications of climate change.
 
-  
+
 The EASIER Data Initiative is in partnership with [Textile](https://linktr.ee/textileio), an open-source technology company with the mission to accelerate the open exchange of information on the internet, as well as University of Maryland’s Department of Geographic Sciences, a leader in using and teaching geospatial perspective and technology to solve humanity’s most pressing issues at local, national, and global scales.
 
-  
+
 To learn more about the EASIER Data Initiative, visit easierdata.org.

--- a/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
+++ b/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
@@ -1,15 +1,19 @@
 ---
 featured: false
-title: FFDW and Human Rights Data Analysis Group (HRDAG) Collaborate to Advance Decentralized Storage for Human Rights Defenders
-description: Collaboration will support outreach and training to accelerate market research for and adoption of decentralized web technologies
+title: FFDW and Human Rights Data Analysis Group (HRDAG) Collaborate to Advance Decentralized
+  Storage for Human Rights Defenders
+description: Collaboration will support outreach and training to accelerate market
+  research for and adoption of decentralized web technologies
 author: Filecoin Foundation for the Decentralized Web
-date: December 7 2021
-sortDate: 2021-12-07
-image: '/images/page-blog/hrdag.png'
+date: 2021-12-07
+sortDate: '2021-12-07'
+image: "/images/page-blog/hrdag.png"
 recommendedPosts: []
-tags: ['Rights', 'Grants']
----
+tags:
+- Rights
+- Grants
 
+---
 ![FFDW and Human Rights Data Analysis Group Collaborate](/images/page-blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.png)
 
 Collaboration will support outreach and training to accelerate market research for and adoption of decentralized web technologies

--- a/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
+++ b/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
@@ -6,7 +6,6 @@ description: Collaboration will support outreach and training to accelerate mark
   research for and adoption of decentralized web technologies
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-12-07
-sortDate: '2021-12-07'
 image: "/images/page-blog/hrdag.png"
 recommendedPosts: []
 tags:

--- a/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
+++ b/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
@@ -7,7 +7,6 @@ tags:
 title: FFDW and MuckRock Collaborate to Bring Flagship Web Resource to the Decentralized
   Web
 date: 2022-05-04
-sortDate: '2022-05-04'
 author: Filecoin Foundation for the Decentralized Web
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce
   its award to MuckRock, a non-profit, collaborative news site that gives people the

--- a/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
+++ b/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
@@ -6,7 +6,7 @@ tags:
 - DocumentCloud
 title: FFDW and MuckRock Collaborate to Bring Flagship Web Resource to the Decentralized
   Web
-date: May 4 2022
+date: 2022-05-04
 sortDate: '2022-05-04'
 author: Filecoin Foundation for the Decentralized Web
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce

--- a/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
+++ b/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
@@ -11,7 +11,6 @@ description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to an
   storage options via their mobile device.
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-11-18
-sortDate: '2021-11-18'
 image: "/images/page-blog/openarchive.png"
 recommendedPosts: []
 tags:

--- a/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
+++ b/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
@@ -1,15 +1,25 @@
 ---
 featured: false
-title: FFDW and OpenArchive Collaborate to Deploy Decentralized Archive for Human Rights Data
-description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our award to OpenArchive, a nonprofit dedicated to advancing human rights by empowering people to collect, verify, and securely preserve mobile media using distributed backends. Through this collaboration, OpenArchive will be able to support decentralized backends for the Save app. This will enable people on the ground capturing images and footage of world events to leverage IPFS and Filecoin and other decentralized storage options via their mobile device.
+title: FFDW and OpenArchive Collaborate to Deploy Decentralized Archive for Human
+  Rights Data
+description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce
+  our award to OpenArchive, a nonprofit dedicated to advancing human rights by empowering
+  people to collect, verify, and securely preserve mobile media using distributed
+  backends. Through this collaboration, OpenArchive will be able to support decentralized
+  backends for the Save app. This will enable people on the ground capturing images
+  and footage of world events to leverage IPFS and Filecoin and other decentralized
+  storage options via their mobile device.
 author: Filecoin Foundation for the Decentralized Web
-date: November 18 2021
-sortDate: 2021-11-18
-image: '/images/page-blog/openarchive.png'
+date: 2021-11-18
+sortDate: '2021-11-18'
+image: "/images/page-blog/openarchive.png"
 recommendedPosts: []
-tags: ['Rights', 'Smartphones', 'Mobile media']
----
+tags:
+- Rights
+- Smartphones
+- Mobile media
 
+---
 ![ffdw and openarchive collaborate to deploy decentralized archive](/images/page-blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.png)
 
 Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our award to [OpenArchive](https://open-archive.org/), a nonprofit dedicated to advancing human rights by empowering people to collect, verify, and securely preserve mobile media using distributed backends. Through this collaboration, OpenArchive will be able to support decentralized backends for the [Save](https://open-archive.org/Save-Launch/) app. This will enable people on the ground capturing images and footage of world events to leverage IPFS and Filecoin and other decentralized storage options via their mobile device.

--- a/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
+++ b/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
@@ -5,7 +5,6 @@ description: FFDW’s commitment to WITNESS will support the creation, authentic
   and preservation of trusted documentation
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-11-04
-sortDate: '2021-11-04'
 image: "/images/page-blog/witness.png"
 recommendedPosts: []
 tags:

--- a/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
+++ b/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
@@ -1,15 +1,20 @@
 ---
 featured: false
 title: FFDW and WITNESS Collaborate to Preserve Authentic Human Rights Records
-description: FFDW’s commitment to WITNESS will support the creation, authentication, and preservation of trusted documentation
+description: FFDW’s commitment to WITNESS will support the creation, authentication,
+  and preservation of trusted documentation
 author: Filecoin Foundation for the Decentralized Web
-date: November 4 2021
-sortDate: 2021-11-04
-image: '/images/page-blog/witness.png'
+date: 2021-11-04
+sortDate: '2021-11-04'
+image: "/images/page-blog/witness.png"
 recommendedPosts: []
-tags: ['Freedom', 'Journalism', 'Press', 'Privacy']
----
+tags:
+- Freedom
+- Journalism
+- Press
+- Privacy
 
+---
 ![ffdw and witness collaborate to preserve authentic human rights records](/images/page-blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.png)
 
 FFDW’s commitment to WITNESS will support the creation, authentication, and preservation of trusted documentation

--- a/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
+++ b/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
@@ -5,8 +5,8 @@ tags:
 - award
 title: FFDW Supports Spritely Networked Communities Institute to Develop Decentralized
   Social Media
-date: August 16 2022
-sortDate: 2022-08-16
+date: 2022-08-16
+sortDate: '2022-08-16'
 author: Filecoin Foundation for the Decentralized Web
 description: Award will further efforts to give people control over identity and relationships
   online

--- a/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
+++ b/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
@@ -6,7 +6,6 @@ tags:
 title: FFDW Supports Spritely Networked Communities Institute to Develop Decentralized
   Social Media
 date: 2022-08-16
-sortDate: '2022-08-16'
 author: Filecoin Foundation for the Decentralized Web
 description: Award will further efforts to give people control over identity and relationships
   online

--- a/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
+++ b/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
@@ -5,7 +5,7 @@ tags:
 - Decentralized Archive
 title: FFDW Works with Prelinger Archives to Make Rare Historic Films More Accessible
   Using the Decentralized Web
-date: August 24 2022
+date: 2022-08-24
 sortDate: '2022-08-24'
 author: Filecoin Foundation for the Decentralized Web
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce

--- a/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
+++ b/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
@@ -6,7 +6,6 @@ tags:
 title: FFDW Works with Prelinger Archives to Make Rare Historic Films More Accessible
   Using the Decentralized Web
 date: 2022-08-24
-sortDate: '2022-08-24'
 author: Filecoin Foundation for the Decentralized Web
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce
   its collaboration with Prelinger Archives, a San Francisco-based historical film

--- a/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
+++ b/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
@@ -6,7 +6,6 @@ tags:
 title: Filecoin Foundation for the Decentralized Web and TechCongress Will Work Together
   to Place More Technologists on Capitol Hill
 date: 2022-06-30
-sortDate: '2022-06-30'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce
   our award to TechCongress, an organization that provides fellowships to bridge the

--- a/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
+++ b/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
@@ -5,7 +5,7 @@ tags:
 - TechCongress
 title: Filecoin Foundation for the Decentralized Web and TechCongress Will Work Together
   to Place More Technologists on Capitol Hill
-date: June 30 2022
+date: 2022-06-30
 sortDate: '2022-06-30'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce

--- a/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
+++ b/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
@@ -7,7 +7,6 @@ tags:
 title: Filecoin Foundation for the Decentralized Web Boosts Harvard Library Innovation
   Lab’s Work to Democratize Open Knowledge
 date: 2022-07-07
-sortDate: '2022-07-27'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce
   an award to the Library Innovation Lab (LIL) at Harvard University to support its

--- a/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
+++ b/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
@@ -6,7 +6,7 @@ tags:
 - Library Innovation Lab
 title: Filecoin Foundation for the Decentralized Web Boosts Harvard Library Innovation
   Lab’s Work to Democratize Open Knowledge
-date: July 07 2022
+date: 2022-07-07
 sortDate: '2022-07-27'
 author: Filecoin Foundation for the Decentralized Web
 description: Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce

--- a/content/blog/guardian-project-annoucement.md
+++ b/content/blog/guardian-project-annoucement.md
@@ -6,7 +6,6 @@ description: FFDW’s commitment to Guardian Project will accelerate adoption of
   storage technology on smartphones through ProofMode and F-Droid
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-12-13
-sortDate: '2021-12-13'
 image: "/images/page-blog/guardian-project.png"
 recommendedPosts: []
 tags:
@@ -22,13 +21,13 @@ Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our aw
 
 "Many aspects of our modern smartphone-driven lives are in the hands of giant internet platforms that practically mandate centralized services for downloading apps and sharing photos. While they claim security and safety as their motivation, the underlying goal is more often control and monetization, and not preservation or privacy,” said Nathan Freitas, founder of Guardian Project. “A decentralized web – a web that’s in the hands of many – paves the way for a world where people can have greater trust in where they store their data and more open access to the applications they need. Our work with FFDW to implement decentralized storage in our apps and code libraries will bring real value to millions of real people around the world.”
 
-The DVD project will be divided into two initial pillars. First, it will build on [ProofMode](https://guardianproject.info/apps/org.witness.proofmode/), a system that enables authentication and verification of multimedia content captured on smartphones, that was co-designed with WITNESS, the human rights organization who pioneered work with video for justice. Using enhanced sensor-derived metadata, hardware fingerprinting, cryptographic signing, and integration with third-party notaries, ProofMode establishes a chain-of-custody and extra layer of “proof” metadata that establishes the authenticity of content while maintaining privacy of the source and subjects. This project will incorporate decentralized storage and communication technology into ProofMode, making the capability available in its own apps on Android and iOS, and to third-party applications that want to incorporate the capability. 
+The DVD project will be divided into two initial pillars. First, it will build on [ProofMode](https://guardianproject.info/apps/org.witness.proofmode/), a system that enables authentication and verification of multimedia content captured on smartphones, that was co-designed with WITNESS, the human rights organization who pioneered work with video for justice. Using enhanced sensor-derived metadata, hardware fingerprinting, cryptographic signing, and integration with third-party notaries, ProofMode establishes a chain-of-custody and extra layer of “proof” metadata that establishes the authenticity of content while maintaining privacy of the source and subjects. This project will incorporate decentralized storage and communication technology into ProofMode, making the capability available in its own apps on Android and iOS, and to third-party applications that want to incorporate the capability.
 
 The funding will also support expanded collaboration with human rights defenders and journalists, as well as partners like WITNESS, Open Archive, Starling Labs, and others, to provide education on ProofMode’s approach to veracity and authentication through the decentralized web and how it can benefit their work, causes, and communities. “We believe in a future where every camera will have a ‘proof mode,’ and we can all more readily trust what we see, without reducing our privacy,” said Carrie Winfrey, Design Lead at Guardian Project.
 
 Second, DVD will accelerate the adoption of decentralized storage technology for [F-Droid](https://www.f-droid.org/), the leading free and open-source app publishing platform. F-Droid has been a key part of Guardian Project’s goal to ensure people have access to the apps they need, even during humanitarian and human rights crises where internet access is often limited. The work that FFDW is funding builds upon previous work in “nearby app sharing” supported by Mozilla, the National Science Foundation, and Open Technology Fund. “The rise of smartphones, where the market is largely dominated by two companies, has exacerbated the issue of who has the right to choose what software is allowed to be installed and where you can download it,” says Hans-Christoph Steiner, Distributed Lead at Guardian Project. “By adding decentralized storage and access to F-Droid, we will make the app ecosystem both less fragile and more free.”
 
-> “Our mission is to permanently preserve humanity’s most important information,” 
+> “Our mission is to permanently preserve humanity’s most important information,”
 
 said Marta Belcher, board chair of the Filecoin Foundation for the Decentralized Web.
 

--- a/content/blog/guardian-project-annoucement.md
+++ b/content/blog/guardian-project-annoucement.md
@@ -1,15 +1,21 @@
 ---
 featured: false
-title: FFDW and Guardian Project Team Up to Bring Decentralized Storage to Content Verification and Distribution on Smartphones
-description: FFDW’s commitment to Guardian Project will accelerate adoption of decentralized storage technology on smartphones through ProofMode and F-Droid 
+title: FFDW and Guardian Project Team Up to Bring Decentralized Storage to Content
+  Verification and Distribution on Smartphones
+description: FFDW’s commitment to Guardian Project will accelerate adoption of decentralized
+  storage technology on smartphones through ProofMode and F-Droid
 author: Filecoin Foundation for the Decentralized Web
-date: December 13 2021
-sortDate: 2021-12-13
-image: '/images/page-blog/guardian-project.png'
+date: 2021-12-13
+sortDate: '2021-12-13'
+image: "/images/page-blog/guardian-project.png"
 recommendedPosts: []
-tags: ['Grants', 'Community', 'Smartphones', 'Rights']
----
+tags:
+- Grants
+- Community
+- Smartphones
+- Rights
 
+---
 ![Leveraging the Dweb to Enhance Free Speech bannner](/images/page-blog/guardian-project-announcement.png)
 
 Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our award to [Guardian Project](https://guardianproject.info/), to support their efforts to integrate decentralized storage into their free and open-source solutions for distribution, authentication, and preservation of essential multimedia and software. Guardian Project is a global collective that develops privacy-focused mobile apps and free licensed, open-source software libraries that can be used by anyone looking to protect data and communications from unjust intrusion, interception, and monitoring. The Decentralizing Veracity and Distribution (DVD) project will focus on preserving content and expanding access for the human rights defenders, frontline journalists, and everyday activists that Guardian Project has sought to empower for over a decade.

--- a/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
+++ b/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
@@ -1,15 +1,22 @@
 ---
 featured: false
 title: Leveraging the Dweb to Enhance Free Speech with the Latest FFDW Award
-description: On September 28, the Filecoin Foundation for the Decentralized Web (FFDW) announced a $5.8 million award to the Freedom of the Press Foundation (FPF) to support the further leveraging of the decentralized web to enhance freedom of speech for journalists.
+description: On September 28, the Filecoin Foundation for the Decentralized Web (FFDW)
+  announced a $5.8 million award to the Freedom of the Press Foundation (FPF) to support
+  the further leveraging of the decentralized web to enhance freedom of speech for
+  journalists.
 author: Filecoin Foundation for the Decentralized Web
-date: Sept 28 2021
-sortDate: 2021-09-28
-image: '/images/page-blog/leveraging-the-dweb-to-enhance-free-speech.png'
+date: 2021-09-28
+sortDate: '2021-09-28'
+image: "/images/page-blog/leveraging-the-dweb-to-enhance-free-speech.png"
 recommendedPosts: []
-tags: ['Freedom', 'Journalism', 'Press', 'Privacy']
----
+tags:
+- Freedom
+- Journalism
+- Press
+- Privacy
 
+---
 ![Leveraging the Dweb to Enhance Free Speech bannner](/images/page-blog/leveraging-the-dweb-to-enhance-free-speech.png)
 
 On September 28, the Filecoin Foundation for the Decentralized Web (FFDW) announced a $5.8 million award to the [Freedom of the Press Foundation](https://freedom.press/) (FPF) to support the further leveraging of the decentralized web to enhance freedom of speech for journalists.

--- a/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
+++ b/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
@@ -7,7 +7,6 @@ description: On September 28, the Filecoin Foundation for the Decentralized Web 
   journalists.
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-09-28
-sortDate: '2021-09-28'
 image: "/images/page-blog/leveraging-the-dweb-to-enhance-free-speech.png"
 recommendedPosts: []
 tags:

--- a/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
+++ b/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
@@ -5,8 +5,8 @@ description: Melba Roy Mouton was a statistician and computer scientist whose co
   to the scientific community during her tenure at NASA not only shaped modern programming
   uses and documentation practices, but also how it is taught to future generations.
 author: Filecoin Foundation for the Decentralized Web
-date: June 01 2021
-sortDate: 2021-06-01
+date: 2021-06-01
+sortDate: '2021-06-01'
 image: "/images/page-blog/melba-roy.jpeg"
 recommendedPosts:
 - History

--- a/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
+++ b/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
@@ -6,7 +6,6 @@ description: Melba Roy Mouton was a statistician and computer scientist whose co
   uses and documentation practices, but also how it is taught to future generations.
 author: Filecoin Foundation for the Decentralized Web
 date: 2021-06-01
-sortDate: '2021-06-01'
 image: "/images/page-blog/melba-roy.jpeg"
 recommendedPosts:
 - History

--- a/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
+++ b/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
@@ -6,7 +6,7 @@ tags:
 - Contemporary art
 title: 'Web3 Sci-Fi: Christopher Kulendran Thomas''s ''Another World'' to Debut at
   London''s Institute of Contemporary Arts'
-date: September 23 2022
+date: 2022-09-23
 sortDate: '2022-09-23'
 author: ''
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) and the Institute

--- a/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
+++ b/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
@@ -7,7 +7,6 @@ tags:
 title: 'Web3 Sci-Fi: Christopher Kulendran Thomas''s ''Another World'' to Debut at
   London''s Institute of Contemporary Arts'
 date: 2022-09-23
-sortDate: '2022-09-23'
 author: ''
 description: 'Filecoin Foundation for the Decentralized Web (FFDW) and the Institute
   of Contemporary Arts (ICA) London today announced that Christopher Kulendran Thomas''s

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -61,7 +61,7 @@ export default {
   async asyncData ({ $content }) {
     const blogPosts = await $content('blog')
       .without(['body'])
-      .sortBy('sortDate', 'desc')
+      .sortBy('date', 'desc')
       .fetch()
     return { blogPosts }
   },

--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -43,7 +43,7 @@ export default {
   async asyncData ({ $content }) {
     const blogPosts = await $content('blog')
       .without(['body'])
-      .sortBy('sortDate', 'desc')
+      .sortBy('date', 'desc')
       .limit(3)
       .fetch()
     return { blogPosts }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,7 +43,7 @@ export default {
   async asyncData ({ $content }) {
     const blogPosts = await $content('blog')
       .without(['body'])
-      .sortBy('sortDate', 'desc')
+      .sortBy('date', 'desc')
       .limit(3)
       .fetch()
     return { blogPosts }


### PR DESCRIPTION
Removed sortDate key in blog posts in favor of date (with proper formatting provided by forestry) for sorting