### PR TITLE
fix: missing site name in config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,7 +11,7 @@ export default {
     slateKey: process.env.SLATE_KEY,
     seo: {
       siteName: 'Filecoin Foundation for the Decentralized Web',
-      siteUrl: ''
+      siteUrl: 'https://ffdweb.org'
     },
     redirects: []
   },


### PR DESCRIPTION
The site name in the config was missing completely. Everything still worked, but forcing relative URLs even when absolute ones were needed.

In other words, we never set a site name and got lucky that everything still worked (or rather, this evaded QA _because_ it worked)